### PR TITLE
files are iterables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea 
+venv*

--- a/cli_wordle.py
+++ b/cli_wordle.py
@@ -104,11 +104,8 @@ def generate_word_list(
 
         letter_frequency: dict = {}
 
-        while True:
-            # read next line:
-            line = f_in.readline()
-            if not line:  # reached end of file
-                break
+        # an open file is an iterable, we can simply enumerate the lines
+        for line in f_in:
             # cut off trailing whitespace and convert to uppercase:
             word = line.strip().upper()
 
@@ -182,8 +179,7 @@ def read_source_from_config(language: str) -> str:
     """
     url: str = ""
     with open("config.txt", "r") as conf:
-        while True:
-            line: str = conf.readline()
+        for line in conf:
             if line.startswith(language):
                 url = line[len(language) + 2:].strip()
                 break
@@ -202,8 +198,7 @@ def list_all_languages() -> list:
     langs: list = []
     reading_sources: bool = False
     with open("config.txt", "r") as conf:
-        while True:
-            line: str = conf.readline()
+        for line in conf:
             if line.startswith("word list sources:"):
                 reading_sources = True
                 continue
@@ -316,8 +311,7 @@ def read_config() -> (int, str):
     length: int = 0
     lang: str = ""
     with open("config.txt", "r") as conf:
-        while True:
-            line: str = conf.readline()
+        for line in conf:
             if line.startswith("word length:"):
                 length = int(line[13:].strip())
                 continue
@@ -391,10 +385,7 @@ def load_words(lang: str, length: int) -> list:
 
     words = []
     with open(filename, "r") as file:
-        while True:
-            line = file.readline()
-            if not line:
-                break
+        for line in file:
             words.append(line.strip())
     return words
 


### PR DESCRIPTION
I saw your twitter posts and that looked interesting. Unfortunately, I can contribute no languages, but reading the source, I thought I might contribute with a patch: files are iterables in Python, so there is no need to .readline(), and test for end of file. It is simply possible to enumerate the lines in a file to read it line by line.

Here is my suggestion for a change.