### PR TITLE
write() and close() do not fail, they raise exceptions.

### DIFF
--- a/cli_wordle.py
+++ b/cli_wordle.py
@@ -47,15 +47,10 @@ def load_word_list_from_url(language: str, url: str) -> bool:
     
     lang_filename: str = f"words_{language.lower()}.txt"
     import requests
-    import os.path
     print(f"Downloading {url} ...")
     r = requests.get(url)
     with open(lang_filename, "xb") as f:
         f.write(r.content)
-    if not os.path.isfile(lang_filename):
-        print(f"could not create '{lang_filename}'.",
-              f"Please download it manually from {url}.")
-        return False
     return True
 
 
@@ -90,8 +85,7 @@ def generate_word_list(
         if not url:
             print(f"Found no source URL for {language} word list.")
             return False
-        if not load_word_list_from_url(language, url):
-            return False
+        load_word_list_from_url(language, url)   # raises OSError if it does not work
 
     # create a filtered list of n letter words:
 
@@ -372,8 +366,10 @@ def load_words(lang: str, length: int) -> list:
     filename = f"words_{lang.lower()}_{length}.txt"
     import os
     if not os.path.isfile(filename):
-        if not generate_word_list(lang, length):
-            print("Could not generate word list file.")
+        try:
+            generate_word_list(lang, length)
+        except OSError as e:
+            print(f"Could not generate word list file: {e}.")
             return []
 
     words = []


### PR DESCRIPTION
Sorry for bothering you again.

I was wondering if it would be legal to simplify file handling here, because all this special casing did not look like Python to me.

I tried this:

```
# dd if=/dev/zero of=/tmp/testfile bs=1024k count=1
# mkfs -t ext2 /tmp/testfile
# mkdir a
# mount /tmp/testfile /a
 # df -Th /a
Filesystem     Type  Size  Used Avail Use% Mounted on
/dev/loop6     ext2  992K   24K  920K   3% /a
```

In there, I can now:

1. run out of space

```
# python3
Python 3.8.10 (default, Nov 26 2021, 20:14:08)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> with open("testfile", "w") as f:
...   f.write("a" * (1024*1024))
...
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
OSError: [Errno 28] No space left on device
```

2. have no permission to write for whatever reason (here: ro filesystem)

```
# umount /a
# mount -o ro /tmp/testfile /a
# cd /a
# python3
Python 3.8.10 (default, Nov 26 2021, 20:14:08)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> with open("testfile", "w") as f:
...   f.write("Keks")
...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OSError: [Errno 30] Read-only file system: 'testfile'
>>>
```

From this, I believe it is okay to not write "Go"-like functions returning error codes, but just rely on Python raising appropriate exceptions when things catch file.

`load_word_list_from_url()` could even be returning bare (no return value, bare "return" instead of the pointless "return True").