### PR TITLE
configparser is your friend.

### DIFF
--- a/cli_wordle.py
+++ b/cli_wordle.py
@@ -177,12 +177,13 @@ def read_source_from_config(language: str) -> str:
     :return: the url of a word list, if present
     """
 
-    from configparser import ConfigParser
+    from configparser import ConfigParser, Error
     from sys import exit
 
     config = ConfigParser()
     config.read("config.txt")
 
+    url = ""
     try:
         url = config.get("word list sources", language)
     except Error as e:
@@ -353,6 +354,7 @@ def write_config(language: str, length: int, url: str = None):
     # write modified list back into the file:
     with open("config.txt", "wt") as f:
         config.write(f)
+
 
 def load_words(lang: str, length: int) -> list:
     """
@@ -736,7 +738,7 @@ if __name__ == '__main__':
     args = p.parse_args()
 
     if args.language:
-        args.language = args.language.lower() # or configparser will hate us later on
+        args.language = args.language.lower()  # or configparser will hate us later on
 
     if args.url:
         if not args.language:

--- a/cli_wordle.py
+++ b/cli_wordle.py
@@ -45,7 +45,7 @@ def load_word_list_from_url(language: str, url: str) -> bool:
     :return: True if the download was successful
     """
     
-    lang_filename: str = f"words_{language.lower()}.txt"
+    lang_filename: str = f"words_{language}.txt"
     import requests
     import os.path
     print(f"Downloading {url} ...")
@@ -78,8 +78,8 @@ def generate_word_list(
     was successfully created
     """
 
-    lang_filename: str = f"words_{language.lower()}.txt"
-    short_filename: str = f"words_{language.lower()}_{word_len}.txt"
+    lang_filename: str = f"words_{language}.txt"
+    short_filename: str = f"words_{language}_{word_len}.txt"
 
     # download the source word list if it's not already stored:
 
@@ -176,15 +176,20 @@ def read_source_from_config(language: str) -> str:
     :param language: the name of the language
     :return: the url of a word list, if present
     """
-    url: str = ""
-    with open("config.txt", "r") as conf:
-        for line in conf:
-            if line.startswith(language):
-                url = line[len(language) + 2:].strip()
-                break
-    if not url:
-        print(f"No source url found for {language},",
-              "please check available languages in config.txt")
+
+    from configparser import ConfigParser
+    from sys import exit
+
+    config = ConfigParser()
+    config.read("config.txt")
+
+    try:
+        url = config.get("word list sources", language)
+    except Error as e:
+        print(f"No source url found for language {language}. ({e})")
+        print("Please check available languages in config.txt.")
+        exit(1)
+
     return url
 
 
@@ -194,17 +199,15 @@ def list_all_languages() -> list:
     
     :return: a list of all available language names
     """
-    langs: list = []
-    reading_sources: bool = False
-    with open("config.txt", "r") as conf:
-        for line in conf:
-            if line.startswith("word list sources:"):
-                reading_sources = True
-                continue
-            if reading_sources and (':' in line):
-                langs.append(line.split(':', 1)[0])
-            if not line:
-                break
+
+    from configparser import ConfigParser
+    config = ConfigParser()
+    config.read("config.txt")
+
+    langs = []
+    for k in config['word list sources']:
+        langs.append(k)
+
     return langs
 
 
@@ -307,17 +310,15 @@ def read_config() -> (int, str):
     
     :return: a tuple of word length and language name
     """
-    length: int = 0
-    lang: str = ""
-    with open("config.txt", "r") as conf:
-        for line in conf:
-            if line.startswith("word length:"):
-                length = int(line[13:].strip())
-                continue
-            elif line.startswith("language:"):
-                lang = line[10:].strip()
-                break
-    return length, lang
+    from configparser import ConfigParser
+
+    config = ConfigParser()
+    config.read("config.txt")
+
+    word_length = config.getint("wordle configuration", "word length", fallback=5)
+    language = config.get("wordle configuration", "language", fallback="en")
+
+    return word_length, language
 
 
 def write_config(language: str, length: int, url: str = None):
@@ -329,34 +330,29 @@ def write_config(language: str, length: int, url: str = None):
     :param url: (optional) source url to be set for the language
     :return: (no return value, just writes to the file)
     """
-    # read the whole file into a list:
-    with open("config.txt", "rt") as conf:
-        data: list = conf.readlines()
-        len_line: int = 0
-        lang_line: int = 0
-        url_line: int = 0
-        for i, line in enumerate(data):
-            if line.startswith("word length:") and length:
-                len_line = i
-            elif line.startswith("language:") and language:
-                lang_line = i
-            elif line.startswith(language) and url:
-                url_line = i
-                
-        # modify the list:
-        if len_line:
-            data[len_line] = f"word length: {length}\n"
-        if lang_line:
-            data[lang_line] = f"language: {language}\n"
-        if url_line:
-            data[url_line] = f"{language}: {url}\n"
-        elif url and language:  # url for new language:
-            data.append(f"{language}: {url}\n")
-        
-    # write modified list back into the file:
-    with open("config.txt", "wt") as conf:
-        conf.writelines(data)
 
+    from configparser import ConfigParser, Error
+    from sys import exit
+    config = ConfigParser()
+
+    # read config from file
+    config.read("config.txt")
+
+    # if no new url is given, preserve the old one for this language
+    if url is None:
+        try:
+            url = config.get("word list sources", language)
+        except Error as e:
+            print(f"{language} is not a valid language. ({e})")
+            exit(1)
+
+    config.set("wordle configuration", "word length", str(length))
+    config.set("wordle configuration", "language", language)
+    config.set("word list sources", language, url)
+
+    # write modified list back into the file:
+    with open("config.txt", "wt") as f:
+        config.write(f)
 
 def load_words(lang: str, length: int) -> list:
     """
@@ -369,7 +365,7 @@ def load_words(lang: str, length: int) -> list:
     :param length: number of letters (n) in each word
     :return: a list of words with n letters
     """
-    filename = f"words_{lang.lower()}_{length}.txt"
+    filename = f"words_{lang}_{length}.txt"
     import os
     if not os.path.isfile(filename):
         if not generate_word_list(lang, length):
@@ -738,7 +734,10 @@ if __name__ == '__main__':
     p.add_argument("-s", "--save", action="store_true", dest="save",
                    help="remember settings for future uses")
     args = p.parse_args()
-    
+
+    if args.language:
+        args.language = args.language.lower() # or configparser will hate us later on
+
     if args.url:
         if not args.language:
             print("You need to specify a language name",

--- a/config.txt
+++ b/config.txt
@@ -1,14 +1,11 @@
-cli-wordle configuration
-------------------------
+[wordle configuration]
+word length = 5
+language = english
 
-word length: 5
-language: English
+[word list sources]
+english = https://github.com/lorenbrichter/Words/raw/master/Words/en.txt
+french = https://github.com/lorenbrichter/Words/raw/master/Words/fr.txt
+german = https://github.com/lorenbrichter/Words/raw/master/Words/de.txt
+spanish = https://github.com/lorenbrichter/Words/raw/master/Words/es.txt
+toki pona = https://github.com/chrisamaphone/nimi2vec/raw/main/wordlist.txt
 
-word list sources:
-------------------
-
-English: https://github.com/lorenbrichter/Words/raw/master/Words/en.txt
-French: https://github.com/lorenbrichter/Words/raw/master/Words/fr.txt
-German: https://github.com/lorenbrichter/Words/raw/master/Words/de.txt
-Spanish: https://github.com/lorenbrichter/Words/raw/master/Words/es.txt
-Toki Pona: https://github.com/chrisamaphone/nimi2vec/raw/main/wordlist.txt


### PR DESCRIPTION
I have another suggestion, but I have no idea if you like it, because it changes the config.txt format a bit.

The Python standard library offers a module named configparser, which can read and write "win.ini" style files. The keys in this file, as well as the values, can contain spaces, but unlike your config, a "=" instead of ":" is used to separate keys and values.

Like in your config, sections can be set up in the file, but the syntax again is slightly different: section names need to be written in [these brackets].

Another change I made was to .lower() the language name in the beginnning after argparse, so all the calls to .lower() in the later code are no longer required.

[Python3 documentation for configparser](https://docs.python.org/3/library/configparser.html)